### PR TITLE
Fix: catch NotImplementedError from pygetwindow on Linux

### DIFF
--- a/kira/modes/vn_autopilot.py
+++ b/kira/modes/vn_autopilot.py
@@ -87,7 +87,9 @@ except ImportError:
 try:
     import pygetwindow as _pgw
     PYGETWINDOW_AVAILABLE = True
-except ImportError:
+except (ImportError, NotImplementedError):
+    # pygetwindow raises NotImplementedError on Linux (not ImportError)
+    _pgw = None
     PYGETWINDOW_AVAILABLE = False
 
 try:
@@ -96,7 +98,6 @@ try:
 except ImportError:
     PYDIRECTINPUT_AVAILABLE = False
     print("   [Autopilot] pydirectinput not installed — run: pip install pydirectinput")
-
 
 # ── Phase 2: Scene intensity states (System 1) ────────────────────────────────
 # These names are now aliases to SessionIntensity enum values imported from


### PR DESCRIPTION
## Problem
`pygetwindow` raises `NotImplementedError` (not `ImportError`) on Linux, causing a fatal crash at import time. Added NotImplementedError to the existing exception handler so Kira boots on Linux.

## Fix
Added `NotImplementedError` to the existing exception handler in `kira/modes/vn_autopilot.py` so the import is gracefully skipped on Linux.

## Testing
- Verified Kira boots successfully on Ubuntu 24.04 (KDE Plasma, X11)
- No regressions observed — pygetwindow functionality is Windows-only by design